### PR TITLE
XOL-2734 Fix for writing 0 integer values into the cell

### DIFF
--- a/Service/ExcelWriter.php
+++ b/Service/ExcelWriter.php
@@ -83,7 +83,7 @@ class ExcelWriter extends AbstractWriter
         $hasMultiRowHeaders = $this->hasMultiRowHeaders($headers);
 
         if ($initRow) {
-            $worksheet->insertNewRowBefore($initRow, 2);
+            $worksheet->insertNewRowBefore($initRow, 1);
         } else {
             $initRow = $this->currentRow;
         }
@@ -128,7 +128,7 @@ class ExcelWriter extends AbstractWriter
 
         $worksheet->calculateColumnWidths(true);
 
-        $this->currentRow += ($hasMultiRowHeaders) ? 2 : 1;
+        $this->currentRow = $initRow + (($hasMultiRowHeaders) ? 2 : 1);
     }
 
     /**
@@ -222,7 +222,7 @@ class ExcelWriter extends AbstractWriter
     private function writeArrays(array $lines)
     {
         $startCell = 'A' . $this->currentRow;
-        $this->handle->getActiveSheet()->fromArray($lines, null, $startCell);
+        $this->handle->getActiveSheet()->fromArray($lines, null, $startCell, true);
         $this->currentRow += count($lines);
     }
 
@@ -234,7 +234,7 @@ class ExcelWriter extends AbstractWriter
     private function writeArray(array $row)
     {
         $startCell = 'A' . $this->currentRow;
-        $this->handle->getActiveSheet()->fromArray([$row], null, $startCell);
+        $this->handle->getActiveSheet()->fromArray([$row], null, $startCell, true);
         $this->currentRow++;
     }
 


### PR DESCRIPTION
PHPExcel by default does not write null values into the excel spreadsheet. It does a non-strict comparison so `0 == null` is true and the value not written into the sheet. This change fixes that so it does a strict check and `0` is written into the excel file. 

This also fixes an issue where an extra empty row was added after the headers
