### PR TITLE
XOL-3823 Report Builder - Exports

### DIFF
--- a/Service/ExcelWriter.php
+++ b/Service/ExcelWriter.php
@@ -16,7 +16,6 @@ class ExcelWriter extends AbstractWriter
     {
         parent::__construct($logger);
         $this->phpexcel = $phpExcel;
-        $this->handle = $this->phpexcel->createPHPExcelObject();
         \PHPExcel_Shared_Font::setAutoSizeMethod(\PHPExcel_Shared_Font::AUTOSIZE_METHOD_EXACT);
     }
 
@@ -27,6 +26,7 @@ class ExcelWriter extends AbstractWriter
      */
     public function setup($filepath)
     {
+        $this->handle = $this->phpexcel->createPHPExcelObject();
         $this->handle->getActiveSheet()->getPageSetup()->setOrientation(\PHPExcel_Worksheet_PageSetup::ORIENTATION_LANDSCAPE);
         $this->filepath = $filepath;
     }


### PR DESCRIPTION
There is a bug that prevents multiple reports to be created in the same script/request.

PHPExcel object keeps the collection of Worksheet objects which needs to be reset for each new XLS file.